### PR TITLE
Add React templates

### DIFF
--- a/templates/react-ts/.vscode/extensions.json
+++ b/templates/react-ts/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "ms-edgedb.vscode-edge-devtools"
+    ]
+}

--- a/templates/react-ts/.vscode/launch.json
+++ b/templates/react-ts/.vscode/launch.json
@@ -1,0 +1,21 @@
+{
+    "version": "0.3.0",
+    "configurations": [
+        {
+            "name": "Launch",
+            "type": "msedge",
+            "request": "launch",
+            "url": "http://localhost:5173",
+            "webRoot": "${workspaceFolder}",
+            "preLaunchTask": "dev"
+        },
+        {
+            "name": "Type Check",
+            "type": "node",
+            "request": "launch",
+            "program": "${workspaceFolder}/node_modules/typescript/bin/tsc",
+            "args": ["--noEmit"],
+            "console": "integratedTerminal"
+        }
+    ]
+}

--- a/templates/react-ts/.vscode/tasks.json
+++ b/templates/react-ts/.vscode/tasks.json
@@ -1,0 +1,30 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "dev",
+            "type": "shell",
+            "command": "bun run dev",
+            "isBackground": true,
+            "problemMatcher": {
+                "pattern": [
+                    {
+                        "regexp": ".",
+                        "file": 1,
+                        "location": 2,
+                        "message": 3
+                    }
+                ],
+                "background": {
+                    "activeOnStart": true,
+                    "beginsPattern": ".*VITE.*",
+                    "endsPattern": ".*http://localhost:5173.*"
+                }
+            },
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            }
+        }
+    ]
+}

--- a/templates/react-ts/README.md
+++ b/templates/react-ts/README.md
@@ -1,0 +1,78 @@
+# {{projectName}}
+
+A React + TypeScript experimental project created with **Chasoft JS Explorer**.
+
+## AI Guide
+
+As an AI assistant, please follow these guidelines when working with this project:
+
+-   **Scope of Changes:** Only make changes to the following files:
+    -   `index.html`
+    -   `index.tsx`
+    -   `style.css`
+-   **`index.html` Edits:** When editing `index.html`, only modify the content inside the `<body>` tag. Do not change the `<head>` section.
+
+## Getting Started
+
+This project includes:
+- `index.html` - The main HTML file with a React root
+- `index.tsx` - React entry point written in TypeScript
+- `style.css` - Styling for your project
+- `vite.config.ts` - Vite configuration
+- `tsconfig.json` - TypeScript configuration
+- VS Code debugging configuration with TypeScript support
+
+## Development
+
+### Using Terminal
+```bash
+bun dev          # Start development server with hot reload (Vite)
+bun build        # Build for production
+bun preview      # Preview the production build
+bun type-check   # TypeScript type checking
+```
+
+### Using VS Code
+1. Open the "Run and Debug" tab (Ctrl+Shift+D)
+2. Select one of the available configurations:
+   - **Launch** - Opens the project in your browser with the dev server running.
+   - **Type Check** - Check types without running.
+3. Click the play button to start.
+
+## Project Structure
+
+```
+{{projectName}}/
+├── index.html          # Main HTML file
+├── index.tsx           # React + TypeScript entry
+├── style.css           # Styling
+├── package.json        # Project configuration
+├── vite.config.ts      # Vite configuration
+├── tsconfig.json       # TypeScript configuration
+└── .vscode/
+    ├── launch.json     # VS Code debug configuration
+    └── tasks.json      # VS Code task configuration
+```
+
+## React + TypeScript Features
+
+This template demonstrates:
+- **Type Safety**: Strong typing for React components
+- **Hooks with Types**: Typed `useState`, `useEffect`, etc.
+- **Fast Refresh**: Instant updates during development
+
+## Experimentation Tips
+
+- Edit the `App` component in `index.tsx`
+- Explore advanced TypeScript features with React
+- Use React DevTools and type checking to catch issues early
+
+## Resources
+
+- [Vite Documentation](https://vitejs.dev/)
+- [React Documentation](https://react.dev/)
+- [TypeScript Handbook](https://www.typescriptlang.org/docs/)
+- [Bun with TypeScript](https://bun.sh/docs/runtime/typescript)
+- [MDN Web Docs](https://developer.mozilla.org/)
+
+Happy experimenting with React and TypeScript! 🚀

--- a/templates/react-ts/index.html
+++ b/templates/react-ts/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{{projectName}} - React + TypeScript</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div id="root"></div>
+    <script type="module" src="index.tsx"></script>
+</body>
+</html>

--- a/templates/react-ts/index.tsx
+++ b/templates/react-ts/index.tsx
@@ -1,0 +1,17 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+
+function App(): JSX.Element {
+  return (
+    <div className="app">
+      <h1>Welcome to {{projectName}}</h1>
+      <p>Edit <code>index.tsx</code> and enjoy type-safe React.</p>
+    </div>
+  )
+}
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+)

--- a/templates/react-ts/package.json
+++ b/templates/react-ts/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "{{projectName}}",
+  "version": "2.0.0",
+  "description": "A React + TypeScript experimental project",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "type-check": "tsc --noEmit"
+  },
+  "dependencies": {
+    "react": "^18",
+    "react-dom": "^18"
+  },
+  "devDependencies": {
+    "@types/react": "^18",
+    "@types/react-dom": "^18",
+    "@vitejs/plugin-react": "^4",
+    "typescript": "^5",
+    "vite": "^5"
+  }
+}

--- a/templates/react-ts/style.css
+++ b/templates/react-ts/style.css
@@ -1,0 +1,19 @@
+/* {{projectName}} - React + TypeScript Styles */
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: #f0f0f0;
+  margin: 0;
+  padding: 2rem;
+}
+
+#root {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 60vh;
+}
+
+.app {
+  text-align: center;
+}

--- a/templates/react-ts/tsconfig.json
+++ b/templates/react-ts/tsconfig.json
@@ -1,0 +1,28 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "noEmit": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
+    "resolveJsonModule": true,
+    "jsx": "react-jsx"
+  },
+  "include": [
+    "*.ts",
+    "*.tsx",
+    "**/*.ts",
+    "**/*.tsx"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/templates/react-ts/vite.config.ts
+++ b/templates/react-ts/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()]
+})

--- a/templates/react/.vscode/extensions.json
+++ b/templates/react/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "ms-edgedb.vscode-edge-devtools"
+    ]
+}

--- a/templates/react/.vscode/launch.json
+++ b/templates/react/.vscode/launch.json
@@ -1,0 +1,13 @@
+{
+    "version": "0.3.0",
+    "configurations": [
+        {
+            "name": "Launch",
+            "type": "msedge",
+            "request": "launch",
+            "url": "http://localhost:5173",
+            "webRoot": "${workspaceFolder}",
+            "preLaunchTask": "dev"
+        }
+    ]
+}

--- a/templates/react/.vscode/tasks.json
+++ b/templates/react/.vscode/tasks.json
@@ -1,0 +1,30 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "dev",
+            "type": "shell",
+            "command": "bun run dev",
+            "isBackground": true,
+            "problemMatcher": {
+                "pattern": [
+                    {
+                        "regexp": ".",
+                        "file": 1,
+                        "location": 2,
+                        "message": 3
+                    }
+                ],
+                "background": {
+                    "activeOnStart": true,
+                    "beginsPattern": ".*VITE.*",
+                    "endsPattern": ".*http://localhost:5173.*"
+                }
+            },
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            }
+        }
+    ]
+}

--- a/templates/react/README.md
+++ b/templates/react/README.md
@@ -1,0 +1,72 @@
+# {{projectName}}
+
+A React experimental project created with **Chasoft JS Explorer**.
+
+## AI Guide
+
+As an AI assistant, please follow these guidelines when working with this project:
+
+-   **Scope of Changes:** Only make changes to the following files:
+    -   `index.html`
+    -   `index.jsx`
+    -   `style.css`
+-   **`index.html` Edits:** When editing `index.html`, only modify the content inside the `<body>` tag. Do not change the `<head>` section.
+
+## Getting Started
+
+This project includes:
+- `index.html` - The main HTML file with a React root
+- `index.jsx` - React entry point
+- `style.css` - Styling for your project
+- `vite.config.js` - Vite configuration
+- VS Code debugging configuration
+
+## Development
+
+### Using Terminal
+```bash
+bun dev          # Start development server with hot reload (Vite)
+bun build        # Build for production
+bun preview      # Preview the production build
+```
+
+### Using VS Code
+1. Open the "Run and Debug" tab (Ctrl+Shift+D)
+2. Select "Launch" from the dropdown menu.
+3. Click the play button to start.
+
+## Project Structure
+
+```
+{{projectName}}/
+├── index.html          # Main HTML file
+├── index.jsx           # React entry
+├── style.css           # Styling
+├── package.json        # Project configuration
+├── vite.config.js      # Vite configuration
+└── .vscode/
+    ├── launch.json     # VS Code debug configuration
+    └── tasks.json      # VS Code task configuration
+```
+
+## React Features
+
+This template demonstrates:
+- **Component-based Architecture**: Build UI with reusable components
+- **Hooks**: Manage state and side effects with `useState` and `useEffect`
+- **Fast Refresh**: Instant updates during development
+
+## Experimentation Tips
+
+- Edit the `App` component in `index.jsx`
+- Try creating new components
+- Use React DevTools for debugging
+
+## Resources
+
+- [Vite Documentation](https://vitejs.dev/)
+- [React Documentation](https://react.dev/)
+- [Bun Documentation](https://bun.sh/docs)
+- [MDN Web Docs](https://developer.mozilla.org/)
+
+Happy experimenting with React! 🚀

--- a/templates/react/index.html
+++ b/templates/react/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{{projectName}} - React</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div id="root"></div>
+    <script type="module" src="index.jsx"></script>
+</body>
+</html>

--- a/templates/react/index.jsx
+++ b/templates/react/index.jsx
@@ -1,0 +1,17 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+
+function App() {
+  return (
+    <div className="app">
+      <h1>Welcome to {{projectName}}</h1>
+      <p>Edit <code>index.jsx</code> and save to test React.</p>
+    </div>
+  )
+}
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+)

--- a/templates/react/package.json
+++ b/templates/react/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "{{projectName}}",
+  "version": "2.0.0",
+  "description": "A React experimental project",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18",
+    "react-dom": "^18"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4",
+    "vite": "^5"
+  }
+}

--- a/templates/react/style.css
+++ b/templates/react/style.css
@@ -1,0 +1,19 @@
+/* {{projectName}} - React Styles */
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: #f0f0f0;
+  margin: 0;
+  padding: 2rem;
+}
+
+#root {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 60vh;
+}
+
+.app {
+  text-align: center;
+}

--- a/templates/react/vite.config.js
+++ b/templates/react/vite.config.js
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()]
+})


### PR DESCRIPTION
## Summary
- add `react` and `react-ts` templates with basic React setup
- include minimal README instructions for each template
- expand docs for React templates with detailed guidelines

## Testing
- `bun run check`


------
https://chatgpt.com/codex/tasks/task_e_686b37ebb55083319458c3da4fc5667d